### PR TITLE
fix: Fix cloud pathing

### DIFF
--- a/src/Services/HLSService.php
+++ b/src/Services/HLSService.php
@@ -33,7 +33,7 @@ final class HLSService
         ]);
     }
 
-    public function getSegment(string $model, int|string $id, string $filename): BinaryFileResponse
+    public function getSegment(string $model, int|string $id, string $filename): RedirectResponse|StreamedResponse
     {
         $resolvedModel = $this->resolveModel($model)->query()->findOrFail($id);
 


### PR DESCRIPTION
This fixes an issue when using s3 with public and private files.

This line will only handle local path which isn't possible if you are using a cloud storage as the path wont exist return `response()->file(Storage::disk($resolvedModel->getHlsDisk())->path($path));`

So this replaces/creates the url required to use cloud storage e.g in this case s3.