### PR TITLE
feat: Added ability to specify paths for laravel ffmpeg

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,27 +104,30 @@ class CustomHLSController
 
 You can configure the package by editing the `config/hls.php` file. Below are the available options:
 
-| Key                                     | Description                                                                                    | Type     | Default               |
-|-----------------------------------------|------------------------------------------------------------------------------------------------|----------|-----------------------|
-| `middlewares`                           | Middleware applied to HLS playlist routes.                                                     | `array`  | `[]`                  |
-| `queue_name`                            | The name of the queue used for HLS conversion jobs.                                            | `string` | `default`             |
-| `enable_encryption`                     | Whether to enable AES-128 encryption for HLS segments.                                         | `bool`   | `true`                |
-| `bitrates`                              | An array of bitrates for HLS conversion.                                                       | `array`  | *See config file*     |
-| `resolutions`                           | An array of resolutions for HLS conversion.                                                    | `array`  | *See config file*     |
-| `video_column`                          | The database column that stores the original video path.                                       | `string` | `video_path`          |
-| `hls_column`                            | The database column that stores the path to the HLS output folder.                             | `string` | `hls_path`            |
-| `progress_column`                       | The database column that stores the conversion progress percentage.                            | `string` | `conversion_progress` |
-| `video_disk`                            | The filesystem disk where original video files are stored. Refer to `config/filesystems.php`.  | `string` | `public`              |
-| `hls_disk`                              | The filesystem disk where HLS output files are stored. Refer to `config/filesystems.php`.      | `string` | `local`               |
-| `secrets_disk`                          | The filesystem disk where encryption secrets are stored.                                       | `string` | `local`               |
-| `hls_output_path`                       | Path relative to `hls_disk` where HLS files are saved.                                         | `string` | `hls`                 |
-| `secrets_output_path`                   | Path relative to `secrets_disk` where encryption secrets are saved.                            | `string` | `secrets`             |
-| `temp_storage_path`                     | Specify where the conversion tmp files are saved.                                              | `string` | `tmp`                 |
-| `model_aliases`                         | An array of model aliases for easy access to HLS conversion.                                   | `array`  | `[]`                  |
-| `register_routes`                       | Whether to register the HLS playlist routes automatically.                                     | `bool`   | `true`                |
-| `delete_original_file_after_conversion` | A bool to turn on/off deleting the original video after conversion.                            | `bool`   | `false`               |
+| Key                                     | Description                                                                                   | Type     | Default               |
+|-----------------------------------------|-----------------------------------------------------------------------------------------------|----------|-----------------------|
+| `middlewares`                           | Middleware applied to HLS playlist routes.                                                    | `array`  | `[]`                  |
+| `queue_name`                            | The name of the queue used for HLS conversion jobs.                                           | `string` | `default`             |
+| `enable_encryption`                     | Whether to enable AES-128 encryption for HLS segments.                                        | `bool`   | `true`                |
+| `bitrates`                              | An array of bitrates for HLS conversion.                                                      | `array`  | *See config file*     |
+| `resolutions`                           | An array of resolutions for HLS conversion.                                                   | `array`  | *See config file*     |
+| `video_column`                          | The database column that stores the original video path.                                      | `string` | `video_path`          |
+| `hls_column`                            | The database column that stores the path to the HLS output folder.                            | `string` | `hls_path`            |
+| `progress_column`                       | The database column that stores the conversion progress percentage.                           | `string` | `conversion_progress` |
+| `video_disk`                            | The filesystem disk where original video files are stored. Refer to `config/filesystems.php`. | `string` | `public`              |
+| `hls_disk`                              | The filesystem disk where HLS output files are stored. Refer to `config/filesystems.php`.     | `string` | `local`               |
+| `secrets_disk`                          | The filesystem disk where encryption secrets are stored.                                      | `string` | `local`               |
+| `hls_output_path`                       | Path relative to `hls_disk` where HLS files are saved.                                        | `string` | `hls`                 |
+| `secrets_output_path`                   | Path relative to `secrets_disk` where encryption secrets are saved.                           | `string` | `secrets`             |
+| `temp_storage_path`                     | Specify where the conversion tmp files are saved.                                             | `string` | `tmp`                 |
+| `temp_hls_storage_path`                 | Specify where the hls conversion tmp files are saved.                                         | `string` | `tmp`                 |
+| `model_aliases`                         | An array of model aliases for easy access to HLS conversion.                                  | `array`  | `[]`                  |
+| `register_routes`                       | Whether to register the HLS playlist routes automatically.                                    | `bool`   | `true`                |
+| `delete_original_file_after_conversion` | A bool to turn on/off deleting the original video after conversion.                           | `bool`   | `false`               |
 
 > 💡 Tip: All disk values must be valid disks defined in your `config/filesystems.php`.
+
+> 💡 Tip: If you are getting issues with "No key URI specified in key info file" please review this documentation https://github.com/protonemedia/laravel-ffmpeg?tab=readme-ov-file#encrypted-hls
 
 ### Model-Level Configuration
 

--- a/src/Jobs/QueueHLSConversion.php
+++ b/src/Jobs/QueueHLSConversion.php
@@ -42,6 +42,9 @@ final class QueueHLSConversion implements ShouldQueue
      */
     public function handle(): void
     {
+        config('laravel-ffmpeg.temporary_files_encrypted_hls', config('hls.temp_hls_storage_path'));
+        config('laravel-ffmpeg.temporary_files_root', config('hls.temp_storage_path'));
+
         CheckForDatabaseColumns::handle($this->model);
 
         $original_path = $this->model->getVideoPath();

--- a/src/config/hls.php
+++ b/src/config/hls.php
@@ -144,6 +144,13 @@ return [
     'temp_storage_path' => 'tmp',
 
     /**
+     * The path where the conversion temp files are stored.
+     *
+     * Default: 'tmp'
+     */
+    'temp_hls_storage_path' => 'tmp',
+
+    /**
      * The model aliases to detect the class for conversion.
      * This should be an array of model class names that
      * implement the ConvertsToHLS trait.


### PR DESCRIPTION
Added this due to the following issues

> Some filesystems, especially on cheap and slow VPSs, are not fast enough to handle the rotating key. This may lead to encoding exceptions, like No key URI specified in key info file. One possible solution is to use a different storage for the keys, which you can specify using the temporary_files_encrypted_hls configuration key. On UNIX-based systems, you may use a tmpfs filesystem to increase read/write speeds:

```
// config/laravel-ffmpeg.php

return [

    'temporary_files_encrypted_hls' => '/dev/shm'

];
```