### PR TITLE
fix: set the storage disk before opening the file

### DIFF
--- a/src/Actions/ConvertToHLS.php
+++ b/src/Actions/ConvertToHLS.php
@@ -6,12 +6,12 @@ namespace AchyutN\LaravelHLS\Actions;
 
 use AchyutN\LaravelHLS\Jobs\UpdateConversionProgress;
 use Exception;
+use FFMpeg\Exception\RuntimeException;
 use FFMpeg\Format\Video\X264;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Storage;
 use InvalidArgumentException;
 use ProtoneMedia\LaravelFFMpeg\Support\FFMpeg;
-use FFMpeg\Exception\RuntimeException;
 
 use function Laravel\Prompts\info;
 use function Laravel\Prompts\progress;

--- a/src/Controllers/HLSController.php
+++ b/src/Controllers/HLSController.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 
 final readonly class HLSController
 {
-    public function __construct(private readonly HLSService $service) {}
+    public function __construct(private HLSService $service) {}
 
     public function key(string $model, int|string $id, string $key): \Illuminate\Http\Response
     {

--- a/src/Services/HLSService.php
+++ b/src/Services/HLSService.php
@@ -55,8 +55,8 @@ class HLSService
         }
 
         return FFMpeg::dynamicHLSPlaylist($resolvedModel->getHlsDisk())
-            ->open($path)
             ->fromDisk($resolvedModel->getHlsDisk())
+            ->open($path)
             ->setKeyUrlResolver(fn ($key) => URL::signedRoute(
                 'hls.key',
                 ['model' => $model, 'id' => $id, 'key' => $key]

--- a/tests/Feature/HLSServiceTest.php
+++ b/tests/Feature/HLSServiceTest.php
@@ -82,8 +82,10 @@ it('redirects to public url for public S3 files', function () {
 function s3filesAssertions(string $visibility, string $url): void
 {
     $disk = Mockery::mock(Illuminate\Contracts\Filesystem\Filesystem::class);
-    $adapter = new class {
-        public function getTemporaryUrl() {
+    $adapter = new class
+    {
+        public function getTemporaryUrl()
+        {
             // this method is mocked, so no implementation needed
         }
     };
@@ -96,7 +98,7 @@ function s3filesAssertions(string $visibility, string $url): void
         $disk->shouldReceive('url')->andReturn($url);
     }
 
-    $service = new \AchyutN\LaravelHLS\Services\HLSService();
+    $service = new HLSService();
 
     $response = (new ReflectionClass($service))
         ->getMethod('serveFileFromDisk')

--- a/tests/Unit/ConvertToHLSTest.php
+++ b/tests/Unit/ConvertToHLSTest.php
@@ -79,8 +79,6 @@ describe('exceptions', function () {
         ConvertToHLS::convertToHLS($original_path, $folderName, $this->video144p);
     })->throws(Exception::class, 'Invalid resolution format: 640-360. Expected format is \'{width}x{height}\'.');
 
-
-
     it('throws runtime exception when save fails during conversion', function () {
         // Mock media object to return fake resolution and bitrate
         $mediaMock = Mockery::mock();
@@ -96,7 +94,7 @@ describe('exceptions', function () {
         $exportMock->shouldReceive('addFormat')->andReturnSelf();
         $exportMock->shouldReceive('onProgress')->andReturnSelf();
         $exportMock->shouldReceive('save')
-            ->andThrow(new \Exception('Simulated failure during save'));
+            ->andThrow(new Exception('Simulated failure during save'));
 
         // Mock FFMpeg::fromDisk()->open() calls
         FFMpeg::shouldReceive('fromDisk')
@@ -111,7 +109,7 @@ describe('exceptions', function () {
         FFMpeg::shouldReceive('cleanupTemporaryFiles')->andReturnNull();
 
         // Fake model with required methods
-        $model = Mockery::mock(\Illuminate\Database\Eloquent\Model::class);
+        $model = Mockery::mock(Illuminate\Database\Eloquent\Model::class);
         $model->shouldReceive('getVideoDisk')->andReturn('video-disk');
         $model->shouldReceive('getHlsDisk')->andReturn('hls-disk');
         $model->shouldReceive('getSecretsDisk')->andReturn('secrets-disk');
@@ -129,11 +127,11 @@ describe('exceptions', function () {
     });
 
     it('throws InvalidArgumentException on invalid resolution format in renameResolution', function () {
-        $method = new ReflectionMethod(\AchyutN\LaravelHLS\Actions\ConvertToHLS::class, 'renameResolution');
+        $method = new ReflectionMethod(ConvertToHLS::class, 'renameResolution');
 
         $invalidResolution = 'invalid_format';
 
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage("Invalid resolution format: {$invalidResolution}. Expected format is '{width}x{height}'.");
 
         $method->invoke(null, $invalidResolution);


### PR DESCRIPTION
Set the storage disk before opening the file to avoid new folder to be be added when the disk is not local.
When opening the file before setting the disk, the disk is set to local.