### PR TITLE
fix: set video path to null after original file deletion

### DIFF
--- a/src/Jobs/QueueHLSConversion.php
+++ b/src/Jobs/QueueHLSConversion.php
@@ -62,7 +62,7 @@ final class QueueHLSConversion implements ShouldQueue
 
         if (config('hls.delete_original_file_after_conversion')) {
             Storage::disk($this->model->getVideoDisk())->delete($original_path);
-            $this->model->setHlsPath(null);
+            $this->model->setVideoPath(null);
         }
 
         $this->model->saveQuietly();

--- a/tests/Feature/HLSTest.php
+++ b/tests/Feature/HLSTest.php
@@ -90,7 +90,12 @@ it('deletes file after conversion', function () {
     );
 
     $this->assertTrue(
-        $videoModel->getHlsPath() === null,
+        $videoModel->getVideoPath() === null,
+        'Video path was not set to null after deleting the original file.'
+    );
+
+    $this->assertTrue(
+        $videoModel->getHlsPath() !== null,
         'HLS path was not set to null after deleting the original file.'
     );
 });

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -60,7 +60,7 @@ abstract class TestCase extends Orchestra
     {
         app('db')->connection()->getSchemaBuilder()->create('videos', function (Blueprint $blueprint) {
             $blueprint->id();
-            $blueprint->string(config('hls.video_column'));
+            $blueprint->string(config('hls.video_column'))->nullable();
             $blueprint->string(config('hls.hls_column'))->nullable();
             $blueprint->integer(config('hls.progress_column'))->default(0);
             $blueprint->timestamps();
@@ -68,7 +68,7 @@ abstract class TestCase extends Orchestra
 
         app('db')->connection()->getSchemaBuilder()->create('error_videos', function (Blueprint $blueprint) {
             $blueprint->id();
-            $blueprint->string(config('hls.video_column').'_error');
+            $blueprint->string(config('hls.video_column').'_error')->nullable();
             $blueprint->string(config('hls.hls_column').'_error')->nullable();
             $blueprint->integer(config('hls.progress_column').'_error')->default(0);
             $blueprint->timestamps();


### PR DESCRIPTION
Ensure the video path is cleared when the original file is deleted.